### PR TITLE
BXC-2611 - Upload directory fixes

### DIFF
--- a/server/lib/deposit/submit-zip.js
+++ b/server/lib/deposit/submit-zip.js
@@ -22,6 +22,7 @@ const config = require('../../config');
 const SwordError = require('../errors').SwordError;
 
 var options = { dir: config.UPLOADS_DIRECTORY }
+tmp.setGracefulCleanup();
 
 function makeZip(submission) {
   return new Promise(function(resolve, reject) {
@@ -106,6 +107,9 @@ function postZip(form, zipFile, depositorEmail) {
         }));
       } else {
         resolve();
+        fs.unlink(zipFile, (err) => {
+          if (err) throw err;
+        });
       }
     });
   });

--- a/server/lib/deposit/submit-zip.js
+++ b/server/lib/deposit/submit-zip.js
@@ -52,6 +52,9 @@ function makeZip(submission) {
           archive.append(submission[name], { name: name });
         } else {
           archive.append(fs.createReadStream(submission[name]), { name: name });
+          fs.unlink(submission[name], (err) => {
+            if (err) throw err;
+          });
         }
       });
 

--- a/server/lib/deposit/submit-zip.js
+++ b/server/lib/deposit/submit-zip.js
@@ -21,9 +21,11 @@ const tmp = require('tmp');
 const config = require('../../config');
 const SwordError = require('../errors').SwordError;
 
+var options = { dir: config.UPLOADS_DIRECTORY }
+
 function makeZip(submission) {
   return new Promise(function(resolve, reject) {
-    tmp.tmpName(function(err, zipFile) {
+    tmp.tmpName(options, function(err, zipFile) {
       /* istanbul ignore next */
       if (err) {
         reject(err);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2611

Prevents failures caused by filling /tmp with uploads.
* Zipped submission packages configured to go to uploads directory rather than system default tmpdir
* Cleanup uploaded files after they have been zipped up
