### PR TITLE
Check for null/undefined value during evaluation of lookups

### DIFF
--- a/server/lib/arrow/evaluate.js
+++ b/server/lib/arrow/evaluate.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const isEmpty = require('./utils').isEmpty;
+const logging = require('../../lib/logging');
 
 function evaluateString(expression) {
   return { type: 'string', value: expression.value };
@@ -22,9 +23,10 @@ function evaluateString(expression) {
 function evaluateLookup(expression, context) {
   let value = context;
   for (let i = 0; i < expression.path.length; i++) {
-    if (expression.path[i] in value) {
+    if (value !== undefined && value !== null && expression.path[i] in value) {
       value = value[expression.path[i]];
     } else {
+      logging.debug("Unable to find value for " + expression.path[i] + " in context " + context);
       value = undefined;
       break;
     }

--- a/server/lib/arrow/evaluate.js
+++ b/server/lib/arrow/evaluate.js
@@ -26,7 +26,7 @@ function evaluateLookup(expression, context) {
     if (value !== undefined && value !== null && expression.path[i] in value) {
       value = value[expression.path[i]];
     } else {
-      logging.debug("Unable to find value for " + expression.path[i] + " in context " + context);
+      logging.debug('Unable to find value for ' + expression.path[i] + ' in context ' + context);
       value = undefined;
       break;
     }


### PR DESCRIPTION
This prevents an error from occurring when a blank value is selected from a vocabulary field which allows blanks